### PR TITLE
Add event listeners to settings buttons & press enter to guess

### DIFF
--- a/gamestates.js
+++ b/gamestates.js
@@ -9,109 +9,154 @@
  */
 let state = {
     menuState: {
-    container: document.querySelector('.menuCon'),
-    hide: false,
-    startButton: document.querySelector('#startgameButton'),
-    settingsButton: document.querySelector('#settingsButton'),
-    highscoreButton: document.querySelector('#hightScoreButton'),
-    rulesButton: document.querySelector('#rulesButton')
+        container: document.querySelector('.menuCon'),
+        hide: false,
+        startButton: document.querySelector('#startgameButton'),
+        settingsButton: document.querySelector('#settingsButton'),
+        highscoreButton: document.querySelector('#hightScoreButton'),
+        rulesButton: document.querySelector('#rulesButton')
     },
     settingsState: {
-    container: document.querySelector('.settingsCon'),
-    hide: true
+        container: document.querySelector('.settingsCon'),
+        hide: true,
+        buttons: {
+            showBotsGuessButton: document.querySelector('#showOpponentsButton'),
+            timePressureButton: document.querySelector('#timePressureButton')
+        }
     },
     highscoreState: {
-    container: document.querySelector('.highScoreCon'),
-    hide: true
+        container: document.querySelector('.highScoreCon'),
+        hide: true
     },
     // the state between menu and actual gameplay
     newGameState: {
-    container: document.querySelector('.newGameCon'),
-    hide: true,
-    selectedBots: [],
-    /** Changes to gameplaystate onclick. */
-    startPlayingButton: document.querySelector('#submitUsername'),
-    /** NodeList of all bot checkboxes. */
-    botCheckboxes: document.querySelectorAll('.newGameCon input[type="checkbox"]')
+        container: document.querySelector('.newGameCon'),
+        hide: true,
+        selectedBots: [],
+        /** Changes to gameplaystate onclick. */
+        startPlayingButton: document.querySelector('#submitUsername'),
+        /** NodeList of all bot checkboxes. */
+        botCheckboxes: document.querySelectorAll('.newGameCon input[type="checkbox"]')
     },
     gameplayState: {
-    container: document.querySelector('.gameCon'),
-    hide: true
+        container: document.querySelector('.gameCon'),
+        hide: true,
+        yellowContainer: document.querySelector('.gameCon .yellowContainer'),
+        userGuess: document.querySelector('.user-guess'),
+        botContainer: document.querySelector('.display-bots')
     },
     rulesState: {
-    container: document.querySelector('.rulesCon'),
-    hide: true
+        container: document.querySelector('.rulesCon'),
+        hide: true
     },
     backToMenuButton: document.querySelectorAll('.backToMenuButton')
-   }
-    
-   /**
-    * Add click event listener to buttons on page load.
-    */
-   window.addEventListener('load', function () {
+}
+
+/**
+ * Add click event listener to buttons on page load.
+ */
+window.addEventListener('load', function () {
     // highscore button
     state.menuState.highscoreButton.addEventListener('click', () => {
-    toggleDisplay(state.highscoreState);
+        toggleClass(state.highscoreState, 'hide');
     })
     // settings button
     state.menuState.settingsButton.addEventListener('click', () => {
-    toggleDisplay(state.settingsState);
+        toggleClass(state.settingsState, 'hide');
     })
     // start button
     state.menuState.startButton.addEventListener('click', () => {
-    toggleDisplay(state.newGameState);
-    // empty array of user selected bots
-    state.newGameState.selectedBots = [];
-    // reset checkboxes to unchecked
-    state.newGameState.botCheckboxes.forEach(checkbox => {
-    checkbox.checked = false;
-    })
+        toggleClass(state.newGameState, 'hide');
+        // empty array of user selected bots
+        state.newGameState.selectedBots.length = 0;
+        // reset checkboxes to unchecked
+        state.newGameState.botCheckboxes.forEach(checkbox => {
+            checkbox.checked = false;
+        })
     })
     // start playing button, after name is entered and bots selected
     state.newGameState.startPlayingButton.addEventListener('click', () => {
-    if (3 <= state.newGameState.selectedBots.length) {
-    toggleDisplay(state.gameplayState);
-    }
-    document.querySelector('.newGameCon p').textContent = 'Du måste välja minst 3st motståndare.';
+        if (2 <= state.newGameState.selectedBots.length) {
+            toggleClass(state.gameplayState, 'hide');
+            printSelectedBots();
+        }
+        document.querySelector('.newGameCon p').textContent = 'Select at least 2 opponents.';
     })
     // rules button
     state.menuState.rulesButton.addEventListener('click', () => {
-    toggleDisplay(state.rulesState);
+        toggleClass(state.rulesState, 'hide');
     })
     // adds event listeners to all back-to-menu-buttons
     for (const button of state.backToMenuButton) {
-    button.addEventListener('click', () => {
-    toggleDisplay(state.menuState);
-    })
+        button.addEventListener('click', () => {
+            toggleClass(state.menuState, 'hide');
+            state.newGameState.selectedBots.length = 0;
+        })
     }
-   })
-    
-   /**
-    * Toggle visibility of html-element.
-    * @param {HTMLDivElement} gameState The selected game state recieved from event listener.
-    */
-   function toggleDisplay(gameState) {
+
+    for (const key in state.settingsState.buttons) {
+        if (state.settingsState.buttons.hasOwnProperty(key)) {
+            const button = state.settingsState.buttons[key];
+            button.addEventListener('click', () => {
+                changeButtonStyle(button, 'buttonClicked');
+            })
+        }
+    }
+})
+
+/**
+ * Toggle visibility of html-element.
+ * @param {(HTMLDivElement|HTMLButtonElement)}  gameState The selected game state recieved from event listener.
+ */
+function toggleClass(gameState, classToToggle) {
     // show selected game state if it is hidden
     if (gameState.hide === true) {
-    show(gameState);
-    // hide everything but selected game state and back to menu button
-    for (const key in state) {
-    if (state[key] != gameState && state[key] != state.backToMenuButton) {
-    hide(state[key]);
-    }
-    }
+        show(gameState, classToToggle);
+        // hide everything but selected game state and back to menu button
+        for (const key in state) {
+            if (state[key] != gameState && state[key] != state.backToMenuButton) {
+                hide(state[key], classToToggle);
+            }
+        }
     }
     // hide game state if it is not hidden
     else if (gameState.hide === false) {
-    hide(gameState);
+        hide(gameState, classToToggle);
     }
-   }
+}
 
-   function show(gameState) {
+/**
+ * Remove class and change 'hide' property value to show html element.
+ * @param {HTMLDivElement} gameState - the game state container to remove a class on.
+ * @param {string} classToToggle - the class to remove.
+ */
+function show(gameState, classToToggle) {
     gameState.hide = false;
-    gameState.container.classList.remove('hide');
-   }
-   function hide(gameState) {
+    gameState.container.classList.remove(classToToggle);
+}
+
+/**
+ * Add class and change 'hide' property value to hide html element.
+ * @param {HTMLDivElement} gameState - the game state container to add a class to.
+ * @param {string} classToToggle - the class to add.
+ */
+function hide(gameState, classToToggle) {
     gameState.hide = true;
-    gameState.container.classList.add('hide');
-   }
+    gameState.container.classList.add(classToToggle);
+}
+
+/**
+ * Toggle classes on buttons and change innerhtml.
+ * @param {HTMLButtonElement} button - the button as html element.
+ * @param {string} classToToggle - the class to toggle.
+ */
+function changeButtonStyle(button, classToToggle) {
+    if (button.classList.contains(classToToggle)) {
+        button.querySelector('span').innerHTML = 'on';
+        button.classList.remove(classToToggle);
+    }
+    else {
+        button.querySelector('span').innerHTML = 'off';
+        button.classList.add(classToToggle);
+    }
+}

--- a/gamestates.js
+++ b/gamestates.js
@@ -78,7 +78,6 @@ window.addEventListener('load', function () {
     state.newGameState.startPlayingButton.addEventListener('click', () => {
         if (2 <= state.newGameState.selectedBots.length) {
             toggleClass(state.gameplayState, 'hide');
-            printSelectedBots();
         }
         document.querySelector('.newGameCon p').textContent = 'Select at least 2 opponents.';
     })
@@ -94,6 +93,17 @@ window.addEventListener('load', function () {
         })
     }
 
+    //fixes input with enter button
+    document.addEventListener("keyup", function (event) {
+        if (event.keyCode === 13) {
+            event.preventDefault();
+            if (state.gameplayState.hide == false) {
+                checkUserGuess();
+            }
+        }
+    });
+
+    // add event listners to buttons in settingsState
     for (const key in state.settingsState.buttons) {
         if (state.settingsState.buttons.hasOwnProperty(key)) {
             const button = state.settingsState.buttons[key];
@@ -102,6 +112,14 @@ window.addEventListener('load', function () {
             })
         }
     }
+
+    state.settingsState.buttons.showBotsGuessButton.addEventListener('click', () => {
+        // vad som händer när man klickar på show bots previous guesses
+    })
+
+    state.settingsState.buttons.timePressureButton.addEventListener('click', () => {
+        // vad som händer när man klickar på tidpressknappen
+    })
 })
 
 /**

--- a/index.html
+++ b/index.html
@@ -120,14 +120,14 @@
     <div class="settingsCon container hide">
 
         <h2>Settings</h2>
-        <button id="showOpponentsButton" type="button" value="Show opponents:">Show opponents: on</button>
+        <button id="showOpponentsButton" type="button" value="Show opponents:">Show opponents: <span>on</span></button>
         <button id="levelButton" type="button" value="Level">level:</button>
         <select id="selectRange">
             <option value="Range">Range 0-20</option>
             <option value="Range">Range 0-100</option>
             <option value="Range">Range 0-1000</option>
         </select>
-        <button id="timePressureButton" type="button" value="Time pressure:">Time pressure: off</button>
+        <button id="timePressureButton" type="button" value="Time pressure:">Time pressure: <span>on</span></button>
 
         <!-- OSKARS KOD ? KAN KOMMENTERAS UT MEN DÅ FÅR JAG FELMEDDELANDE...  -->
         <form class="settings-input" action="javascript:void(0);">

--- a/script.js
+++ b/script.js
@@ -36,12 +36,14 @@ let bots = ["Du", "AverageBert", "LowBert" , "RandomBert", "HighBert", "DumbBert
 // state.newGameState.selectedBots
 let startButton = document.querySelector('#startgameButton');
 //NEED A IF STATEMENT SO ITS ONLY WORK IN THE GAME MODE
+/*
 document.addEventListener("keyup", function(event) {
     if (event.keyCode === 13) {
      event.preventDefault();
      checkUserGuess();
     }
 });
+*/
 
 // start playing button in newGameState
 state.newGameState.startPlayingButton.addEventListener('click', () => {
@@ -239,7 +241,7 @@ function displayOutput(player, guess, result){
             scoreList[bots.indexOf(player)] += 300;
             scoreList[bots.indexOf(player)] = Math.round(scoreList[bots.indexOf(player)]/numberOfGuesses[bots.indexOf(player)]);
             console.log(scoreList + " scoreList in case win")
-            swapPic.src = "https://www.wyzowl.com/wp-content/uploads/2019/01/winner-gif.gif";
+            // NOT USED RIGHT NOW swapPic.src = "https://www.wyzowl.com/wp-content/uploads/2019/01/winner-gif.gif";
             swapText.innerHTML = guess + " Var rätt. " + player + " vann!";
             display(player + " gissade rätt: " + guess);
             break;

--- a/style.css
+++ b/style.css
@@ -107,11 +107,12 @@ h2, .checkUserGuess, #inputUsername {
   background-color: #55608E;
 }
 
+/* BACKGROUND CHANGES ON CLICK EVENT SO THIS IS NOT NEEDED
 #timePressureButton {
   color: #5F193D;
   background-color: #55608E;
-
 }
+ */
 
 p {
   color: #55608E;
@@ -234,4 +235,10 @@ input:checked + .slider:before {
   -webkit-transform: translateX(26px);
   -ms-transform: translateX(26px);
   transform: translateX(26px);
+}
+
+/* Change background when buttons in 'settings' are clicked */
+.buttonClicked{
+  color: #5F193D;
+  background-color: #55608E;
 }


### PR DESCRIPTION
- **Buttons in settings state changes background color and ’on’/’off’ inner text on click.** The actual settings are not changed on click; only the styling. The function(s) can be adapted to all buttons in application as well, if needed.
- **@ozckarr's code block for press-enter-to-guess is moved to gamestates.js.** It's now working properly. I commented out the old cold block left in script.js just in case.
- I added event listeners for 2 separate settings buttons, put whatever function(s) that should be called when you press on them, there (gamestates.js). 
- (Less important) I commented out 'swapPic' variable because it's not defined and not being used. Remove it if nobody is using it.